### PR TITLE
Fixed the issue the sample image doesn't start on aks cluster

### DIFF
--- a/chap02/v1.0/app.py
+++ b/chap02/v1.0/app.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from flask import Flask, render_template, request
 import os,random,socket
 

--- a/chap02/v2.0/app.py
+++ b/chap02/v2.0/app.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from flask import Flask, render_template, request
 import os,random,socket
 


### PR DESCRIPTION
## Overview
Fixed the error by adding a python shebang.
I guess this is depending on machine environment.

## Detail
Faced the below error when I docker build in local machine, and the image doesn't start running on aks cluster as well.

Error on `docker run`:
```
OSError: [Errno 8] Exec format error
```

Error on aks cluster:
```
% kubectl get pod
NAME                                    READY   STATUS             RESTARTS   AGE
photoview-deployment-788469f876-46dq9   0/1     CrashLoopBackOff   828        2d22h
...
```

```
% kubectl describe pod photoview-deployment-788469f876-46dq9
...
Containers:
  photoview-container:
...
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       Completed
      Exit Code:    0
...
  Type              Status
  Initialized       True
  Ready             False
  ContainersReady   False
  PodScheduled      True
...
Events:
  Type     Reason   Age                        From                               Message
  ----     ------   ----                       ----                               -------
  Warning  BackOff  3m37s (x19502 over 2d22h)  kubelet, aks-nodepool1-90889138-1  Back-off restarting failed container
```

situation for my local machine:
* Ubuntu 18.04 (WSL)